### PR TITLE
overview ml 2

### DIFF
--- a/lectures-materials.md
+++ b/lectures-materials.md
@@ -127,9 +127,9 @@ Most of published results still rely on some statistical inference. With this le
 ## 12. Advanced Machine Learning with Neuroimaging and Nilearn
 **Instructor:** Jérôme Dockès
 
-* 
-* 
-* 
+* Understand the challenges of learning from high-dimensional data
+* Learn about tools to mitigate the issue: feature selection and dimensionality reduction
+* Train a machine-learning pipeline on fMRI data and evaluate its prediction performance
 
 **Pre-recorded lecture video:** 
 


### PR DESCRIPTION
note: not sure if the titles of the modules are frozen or not?
the titles of the ml modules don't really reflect how it has been divided, maybe "Intro to ML part 1: supervised learning" and "Intro to ML part 2: dimensionality reduction techniques" would be more accurate