### PR TITLE
Remove extra "Back to home" links on pages

### DIFF
--- a/lectures-materials.md
+++ b/lectures-materials.md
@@ -10,8 +10,6 @@ description: Links to the pre-recorded lectures and material
 
 [QLS612 Slack workspace](https://qls612-bhs.slack.com)
 
-[Back to home](./)
-
 ___
 
 ## 1. Reproducibility in Life Sciences

--- a/tut-schedule.md
+++ b/tut-schedule.md
@@ -8,8 +8,6 @@ description: The schedule for the course
 
 **Classroom:** room 189 (QLS Conference Room) of 550 Sherbrooke Street West
 
-**Back to home** [QLS612 website](./)
-
 | Date              | Time          | Event                                 |
 |-----------------|-------------|-------------------------------------|
 | Monday May 1st    | 09:00-10:30   | 1. Introduction to Reproducibility    |


### PR DESCRIPTION
- Website header button now serves as "Home" button