### PR TITLE
Update (mainly Windows) setup instructions + change PAT setup to SSH key setup

### DIFF
--- a/_includes/extra-git-setup.html
+++ b/_includes/extra-git-setup.html
@@ -7,7 +7,7 @@
 </p>
 
 <p>
-    Type the following commands in a terminal. Make sure to use the email associated with your GitHub account. 
+    Type the following commands in a terminal. Make sure to use the email associated with your GitHub account.
     The <code>user.name</code> can be any name you want to appear as the author of your commits, but we recommend using the name associated with your GitHub profile.
 </p>
 <p>

--- a/_includes/extra-git-setup.html
+++ b/_includes/extra-git-setup.html
@@ -2,11 +2,13 @@
 <h4>Git configuration</h4>
 
 <p>
-    In case you have never used Git on your computer, you may have to configure it.
+    If you have never used Git on your computer, you may have to configure it.
+    The following instructions assume you have already created a GitHub account.
 </p>
 
 <p>
-    Type the following commands, and make sure to use the name and email associated with your GitHub account.
+    Type the following commands in a terminal. Make sure to use the email associated with your GitHub account. 
+    The <code>user.name</code> can be any name you want to appear as the author of your commits, but we recommend using the name associated with your GitHub profile.
 </p>
 <p>
 <pre>
@@ -18,50 +20,3 @@ git config --global core.autocrlf true
 <p>
     <b>Tip:</b> You can review your configuration at any time with: <code>git config --list</code>
 </p>
-
-<h4>Create a personal access token (PAT) for GitHub</h4>
-
-<p>
-    To authenticate to GitHub from the command line, you will use a PAT instead of your GitHub account password.
-    In this course, when using a git command that prompts you for your password, you will enter this token.
-</p>
-<p>
-    Log in to your GitHub account, and follow
-    <a href="https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token">
-    these instructions to create a fine-grained PAT</a>.
-</p>
-<p>
-    Use an informative name for the token, such as <b>QLSC612_PAT</b>.
-    <ul>
-        <li>Under <code>Expiration</code>, select 7 days</li>
-        <li>Under <code>Resource owner</code>, select your username</li>
-        <li>Under <code>Repository access</code>, select All repositories</li>
-        <li>Under <code>Permissions</code>, navigate to Contents and change the access level to Read and write</li>
-    </ul>
-</p>
-<p>
-    Then, click <code>Generate token</code>, and copy and store the resulting token value in a secure location.
-</p>
-<aside>
-    <p><b>DISCLAIMER</b></p>
-    <p>
-        PATs are like passwords, and it is not best practice to save them in plain text on your computer!!
-        As an exception for this course, you are using a very short-term PAT with limited permissions
-        so that you can push to GitHub repositories from the command line without downloading additional tools.
-    </p>
-</aside>
-<p>
-    To use git/GitHub for your own purposes after this course,
-    you can use the GitHub CLI or Git Credential manager instead of creating a PAT.
-</p>
-<p>
-    For more info, see:
-    <ul>
-        <li><a href="
-            https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#keeping-your-personal-access-tokens-secure">
-            Keeping your personal access tokens secure</a></li>
-        <li><a href="https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github#authenticating-with-the-command-line">
-            Authenticating with the command line</a></li>
-    </ul>
-</p>
-</div>

--- a/_includes/gh-ssh-key-setup.html
+++ b/_includes/gh-ssh-key-setup.html
@@ -1,0 +1,32 @@
+<p>
+    To authenticate to GitHub from the command line, you will use an SSH key pair, which is more secure than using your GitHub account password directly.
+</p>
+<ol>
+    <li>
+      In a terminal, <a href="https://docs.github.com/en/authentication/connecting-to-github-with-ssh/checking-for-existing-ssh-keys">check if you have existing SSH keys in the ~/.ssh directory</a>. 
+      A public/private key pair typically has the filename format <code>id_ALGORITHM</code> and <code>id_ALGORITHM.pub</code>. 
+      If you have existing key files, use a custom name for your SSH key pair in step 2.
+    </li>
+    <li>
+      <a href="https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent">Generate a new SSH key and add it to the ssh-agent</a>.
+      <ul>
+        <li>Ensure to use the default file location for saving the key, unless you already have existing keys - in this case, replace just the <code>id_ALGORITHM</code> (e.g., <code>id_ed25519</code>) part of the file location with an informative keyname like <code>id_ed25519_github</code></li>
+        <li>Choose a passphrase you can remember easily, as you will need to use it for certain Git commands</li>
+      </ul>
+    </li>
+    <li>
+      Confirm your key pair was created by running the command:
+      <pre><code>ls -la ~/.ssh</code></pre>
+      You should see two files with your key name, one with <code>.pub</code> (the <b>public</b> key) and one without (the <b>private</b> key - do not share or copy this file!).
+    </li>
+    <li>
+      <a href="https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account">Add the SSH key to your GitHub account</a>. 
+      <ul>
+        <li>Be careful when copying/pasting the public key to not accidentally add spaces or newlines</li>
+        <li>Choose Authentication Key for the key type</li>
+      </ul>
+    </li>
+</ol>
+<p>
+    In this course, when using a Git command that prompts you for your passphrase, enter the passphrase you set for your private key in step 2.
+</p>

--- a/_includes/gh-ssh-key-setup.html
+++ b/_includes/gh-ssh-key-setup.html
@@ -3,8 +3,8 @@
 </p>
 <ol>
     <li>
-      In a terminal, <a href="https://docs.github.com/en/authentication/connecting-to-github-with-ssh/checking-for-existing-ssh-keys">check if you have existing SSH keys in the ~/.ssh directory</a>. 
-      A public/private key pair typically has the filename format <code>id_ALGORITHM</code> and <code>id_ALGORITHM.pub</code>. 
+      In a terminal, <a href="https://docs.github.com/en/authentication/connecting-to-github-with-ssh/checking-for-existing-ssh-keys">check if you have existing SSH keys in the ~/.ssh directory</a>.
+      A public/private key pair typically has the filename format <code>id_ALGORITHM</code> and <code>id_ALGORITHM.pub</code>.
       If you have existing key files, use a custom name for your SSH key pair in step 2.
     </li>
     <li>
@@ -20,7 +20,7 @@
       You should see two files with your key name, one with <code>.pub</code> (the <b>public</b> key) and one without (the <b>private</b> key - do not share or copy this file!).
     </li>
     <li>
-      <a href="https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account">Add the SSH key to your GitHub account</a>. 
+      <a href="https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account">Add the SSH key to your GitHub account</a>.
       <ul>
         <li>Be careful when copying/pasting the public key to not accidentally add spaces or newlines</li>
         <li>Choose Authentication Key for the key type</li>

--- a/_includes/vs-code-extensions.html
+++ b/_includes/vs-code-extensions.html
@@ -5,22 +5,9 @@
 
     <b>Required extensions</b>
     <ul>
-        <li><a href="https://marketplace.visualstudio.com/items?itemName=ms-python.python">Python Extension Pack</a> (note that you will need to reload VSCode after installing this)</li>
-        <li><a href="https://marketplace.visualstudio.com/items?itemName=ms-vsliveshare.vsliveshare">Live Share</a>
-            (Note you may need to press "Ctrl/Cmd+Shift+P" and type "install extensions" again after installing this)
-        </li>
+        <li><a href="https://marketplace.visualstudio.com/items?itemName=ms-python.python">Python Extension Pack</a> (note: you will need to reload VSCode after installing this)</li>
         <li><a href="https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker">Docker</a></li>
         <li><a href="https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl">WSL</a></li>
-    </ul>
-
-    <b>Recommended extensions</b>
-    <ul>
-        <li><a href="https://marketplace.visualstudio.com/items?itemName=foxundermoon.shell-format">Shell format</a></li>
-        <li><a href="https://marketplace.visualstudio.com/items?itemName=timonwong.shellcheck">Shellcheck</a></li>
-        <li><a href="https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter">Jupyter Notebooks</a></li>
-        <li><a href="https://marketplace.visualstudio.com/items?itemName=usernamehw.errorlens">ErrorLens</a></li>
-        <li><a href="https://marketplace.visualstudio.com/items?itemName=sourcery.sourcery">Sourcery</a></li>
-        <li><a href="https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens">GitLens</a></li>
     </ul>
 
 </div>

--- a/setup/linux.md
+++ b/setup/linux.md
@@ -25,6 +25,12 @@ If you are prompted to install it follow the instructions on-screen to do so.
 
 {% include extra-git-setup.html %}
 
+#### Creating an SSH key for GitHub
+
+When following the GitHub docs below, make sure to select the **Linux** instructions.
+
+{% include gh-ssh-key-setup.html %}
+
 ### VSCode
 
 1. Go to [this page](https://code.visualstudio.com/) and click the download

--- a/setup/mac.md
+++ b/setup/mac.md
@@ -34,6 +34,12 @@ If you do **not** see something like “git version X.XX.X” printed out, then 
 
 {% include extra-git-setup.html %}
 
+#### Creating an SSH key for GitHub
+
+When following the GitHub docs below, make sure to select the **Mac** instructions.
+
+{% include gh-ssh-key-setup.html %}
+
 ### VSCode
 
 1. Go to [this page](https://code.visualstudio.com/) and click the download button.
@@ -93,7 +99,7 @@ If you do **not** see something like “git version X.XX.X” printed out, then 
 
 1. Go to
    [this page](https://docs.docker.com/desktop/install/mac-install/)
-   and press the button `Docker Deskptop for...` corresponding to the chip of your machine (see the image below).
+   and press the button `Docker Desktop for...` corresponding to the chip of your machine (see the image below).
 
    [![](../assets/images/docker_mac.png)](https://docs.docker.com/desktop/install/mac-install/)
 

--- a/setup/setup.md
+++ b/setup/setup.md
@@ -20,13 +20,16 @@ described below):
    will not be sufficient for this course.
 
 If you foresee any of these being a problem, please reach out to one of the
-instructors (or use the `#help-installation` channel in the QLS612 Slack) for
-what steps you can take to ensure you are ready for the course start.
+instructors (or use the `#help-installation` channel in the QLS612 Slack) **before the start of the course** for
+steps you can take to ensure you are ready for the lectures.
 
 ## Required software
 
-To get the most out of our course, we ask that you arrive with the following
-software **already installed** (or to the best of your ability):
+To get the most out of our course, please arrive with the
+software listed below **already installed** (or to the best of your ability). 
+The rest of this page provides installation procedures for each
+of the above programs, including specific instructions for each of the three major
+operating systems (Windows, Mac OS, and Linux).
 
 - A command-line shell: Bash
 - A version control system: Git
@@ -37,10 +40,6 @@ software **already installed** (or to the best of your ability):
 - Slack
 - Zoom
 - A modern browser
-
-The rest of this page provides more detail on installation procedures for each
-of the above programs, with separate instructions for each of the three major
-operating systems (Windows, Mac OS, and Linux).
 
 ### Some quick general notes on instructions
 
@@ -55,21 +54,11 @@ operating systems (Windows, Mac OS, and Linux).
   we strongly encourage you to uninstall it before following the instructions below.
   You _must_ have Python installed via Miniconda for this course.
 
-### OS-specific installation instructions
-
-Select the link that corresponds to your operating system and follow the
-instructions therein. Please direct any questions to the `#help-installation`
-channel in the QLS612 Slack.
-
-- [Linux]({{ site.url }}/setup/linux.html)
-- [Mac]({{ site.url }}/setup/mac.html)
-- [Windows]({{ site.url }}/setup/windows.html)
-
 ### GitHub account
 
 Go to [https://github.com/join/](https://github.com/join/) and follow the
 on-screen instructions to create an account.
-It is a good idea to associate this
+We recommend associating this
 with your university e-mail (if you have one) as this will entitle you to sign
 up for the [GitHub Student Developer Pack](https://education.github.com/pack)
 which comes with some nice free bonuses.
@@ -87,6 +76,16 @@ Go to [https://zoom.us/download](https://zoom.us/download) and download and inst
 ### Modern web browser
 
 Install Firefox, Chrome, or Safari.
+
+### OS-specific installation instructions
+
+Select the link that corresponds to your operating system and follow the
+instructions provided. Please direct any questions to the `#help-installation`
+channel in the QLS612 Slack.
+
+- [Linux]({{ site.url }}/setup/linux.html)
+- [Mac]({{ site.url }}/setup/mac.html)
+- [Windows]({{ site.url }}/setup/windows.html)
 
 ---
 

--- a/setup/setup.md
+++ b/setup/setup.md
@@ -26,7 +26,7 @@ steps you can take to ensure you are ready for the lectures.
 ## Required software
 
 To get the most out of our course, please arrive with the
-software listed below **already installed** (or to the best of your ability). 
+software listed below **already installed** (or to the best of your ability).
 The rest of this page provides installation procedures for each
 of the above programs, including specific instructions for each of the three major
 operating systems (Windows, Mac OS, and Linux).

--- a/setup/windows.md
+++ b/setup/windows.md
@@ -79,6 +79,12 @@ You already have it, now that you’ve installed the WSL2!
 
 {% include extra-git-setup.html %}
 
+#### Creating an SSH key for GitHub
+
+When following the GitHub docs below, make sure to select the **Linux** instructions.
+
+{% include gh-ssh-key-setup.html %}
+
 ### VSCode (on your Windows)
 
 1. Go to [this page](https://code.visualstudio.com/) and click the download

--- a/setup/windows.md
+++ b/setup/windows.md
@@ -7,9 +7,9 @@ description: Instructions for setting up on Windows
 ### WSL2 (Windows Subsystem for Linux version 2)
 
 WSL (Windows Subsystem for Linux) allows you to use Linux on top of Windows
-natively. 
+natively.
 WSL2 is the latest version of WSL and is more stable with improved performance and compatibility.
-If you already have WSL(1), it is easy to convert to WSL2 (see [Instructions to convert WSL(1) to WSL2](https://learn.microsoft.com/en-us/windows/wsl/install#upgrade-version-from-wsl-1-to-wsl-2)). 
+If you already have WSL(1), it is easy to convert to WSL2 (see [Instructions to convert WSL(1) to WSL2](https://learn.microsoft.com/en-us/windows/wsl/install#upgrade-version-from-wsl-1-to-wsl-2)).
 If your Windows 10 is version 1909 or older,
 see the "Install WSL2 on Windows 10 (older versions)" section on this [page](https://pureinfotech.com/install-windows-subsystem-linux-2-windows-10/).
 
@@ -202,7 +202,7 @@ You should install Docker Desktop after you have successfully installed WSL2.
 5. Whenever you need to run Docker, open **Start (Win key)**, search for
    **Docker Desktop** in your applications, and left click to run the app.
 6. For this course, you should run Docker commands from your **WSL2 Ubuntu
-   terminal**. 
+   terminal**.
    However, in general you can also use Docker command-line tools in **Command Prompt** or **PowerShell**.
 
 The above step-by-step instructions are distilled from

--- a/setup/windows.md
+++ b/setup/windows.md
@@ -7,11 +7,11 @@ description: Instructions for setting up on Windows
 ### WSL2 (Windows Subsystem for Linux version 2)
 
 WSL (Windows Subsystem for Linux) allows you to use Linux on top of Windows
-natively, WSL2 is the most recent version of WSL and it is more stable.
-If you already have WSL(1), it is easy to convert to WSL2
-(see [Instructions to convert WSL(1) to WSL2](https://ericsysmin.com/2019/07/13/converting-wsl-1-operating-systems-to-wsl-2-on-windows/)),
-if your Windows 10 is patched with 1909 or older,
-see [Install WSL2 on Windows 10 1909 or older](https://pureinfotech.com/install-windows-subsystem-linux-2-windows-10/).
+natively. 
+WSL2 is the latest version of WSL and is more stable with improved performance and compatibility.
+If you already have WSL(1), it is easy to convert to WSL2 (see [Instructions to convert WSL(1) to WSL2](https://learn.microsoft.com/en-us/windows/wsl/install#upgrade-version-from-wsl-1-to-wsl-2)). 
+If your Windows 10 is version 1909 or older,
+see the "Install WSL2 on Windows 10 (older versions)" section on this [page](https://pureinfotech.com/install-windows-subsystem-linux-2-windows-10/).
 
 #### Install WSL2 on Windows 10 or 11
 
@@ -23,18 +23,17 @@ see [Install WSL2 on Windows 10 1909 or older](https://pureinfotech.com/install-
    ```powershell
    wsl --install
    ```
-
 3. Restart your computer to finish the WSL installation and continue with the Linux distro setup.
 4. Open **Start (Win key)** and search for **Command Prompt** in your
    applications, right click and select `Run as administrator`.
    Select `Yes` on the prompt that appears asking if you want to allow the app to make changes to your device.
 5. At this point, if you are on a newer version of Windows 10 or Windows 11,
    the command from Step 2 should have installed, in addition to WSL,
-   the latest LTS version of Ubuntu (22.04 LTS at time of writing) as the default distribution.
+   the latest LTS version of Ubuntu (24.04 LTS at time of writing) as the default distribution.
    If this is the case, an Ubuntu terminal will open to resume automatic setup,
    and afterwards will ask you set up a username and password.
-   If this applies to you, skip to Step 9.
-   Otherwise, continue with Step 6.
+   **If this applies to you, skip to Step 9.
+   Otherwise, continue with Step 6.**
 6. In the **Command Prompt**, type the following command to view a list of
    available WSL distros you can install and press Enter:
 
@@ -42,7 +41,7 @@ see [Install WSL2 on Windows 10 1909 or older](https://pureinfotech.com/install-
    wsl --list --online
    ```
 
-7. Type the following command to install a specific distro (Ubuntu-18.04
+7. Type the following command to install a specific distro (Ubuntu-22.04
    recommended) in WSL and press `Enter` (it will start the distro if it has
    already been installed):
 
@@ -51,21 +50,21 @@ see [Install WSL2 on Windows 10 1909 or older](https://pureinfotech.com/install-
    ```
 
 8. Restart your computer, open **Start (Win key)** and search for **Ubuntu**,
-   and click on **Ubuntu \<VERSION-NUMBER\> on Windows (App)**. You should have
-   the **WSL2 Ubuntu 18.04** terminal open. Now, you are ready to rock!
+   and click on the app called **Ubuntu** or **Ubuntu \<VERSION-NUMBER\>**. You should now have
+   the **WSL2 Ubuntu 22.04** terminal open. Now, you are ready to rock!
 9. You will be prompted to `Enter new UNIX username` (this will create a local user account for the **Ubuntu WSL instance**
-   and you will be automatically logged in to Ubuntu `<VERSION-NUMBER>`as this user).
+   and you will be automatically logged in to your Ubuntu distro as this user).
    You can use any combination of alphanumeric characters for your username,
    but a good choice is `<first_initial><last_name>` (e.g., `jsmith` for John Smith).
    You will then be prompted to enter a new password
-   (choose something easy to remember as you will find yourself using it frequently).
+   (choose something easy to remember as you will use it frequently for this course).
 
 From this point on, whenever the instructions specify to **"open/type a command
-in a terminal"**, please assume you are supposed to open/type the command in the
-Ubuntu application (open **Start (Win key)** and search for **Ubuntu**, and
-click **Ubuntu \<VERSION-NUMBER\> on Windows (App)**).
+in a terminal"**, please open/type the command in the
+Ubuntu application (open **Start (Win key)**, search for **Ubuntu**, and
+click **Ubuntu** or **Ubuntu \<VERSION-NUMBER\>**).
 
-References:
+Need more help?
 
 - [https://learn.microsoft.com/en-us/windows/wsl/install](https://learn.microsoft.com/en-us/windows/wsl/install)
 - [https://ubuntu.com/tutorials/install-ubuntu-on-wsl2-on-windows-11-with-gui-support#2-install-wsl](https://ubuntu.com/tutorials/install-ubuntu-on-wsl2-on-windows-11-with-gui-support#2-install-wsl)
@@ -85,23 +84,23 @@ You already have it, now that you’ve installed the WSL2!
 1. Go to [this page](https://code.visualstudio.com/) and click the download
    button, then run the `.exe` file.
 2. Leave all the defaults during the installation with the following exception:
-   - Please make sure the box labeled "Register Code as an editor for supported
+   - Make sure the box labeled "Register Code as an editor for supported
      file types" is selected
 
 #### VSCode extensions
 
-These extensions will allow you to work with the WSL2 Ubuntu with GUI.
+These extensions will allow you to work with WSL2 Ubuntu more seamlessly in VSCode.
 
 1. Open Visual Studio Code, click on the **Extensions** icon in the left sidebar
-   (or press `Ctrl+Shift+X`), and search for and install the `WSL` extension
+   (or press `Ctrl+Shift+X`), and search for and install the **WSL** extension
    (usually, VSCode can automatically detect your WSL Ubuntu installation and remind you to install related extensions).
 1. In a **terminal** (Ubuntu), type `code .` and press `Enter`.
    You should see a  message reading `Installing VS Code Server` and then a new VSCode window
-   (entitled: `Get Started - <USERNAME> [WSL: Ubuntu <VERSION-NUMBER>]` - Visual Studio Code) will open up.
-   An indicator reading `WSL` should be visible in the bottom left corner of the window.
-1. In the WSL VSCode window, open the Extensions panel (or `Ctrl+Shift+X`).
-   In the search bar, search for each of the following extensions and click `Install`
-   (or `Install in WSL: Ubuntu`, depending on whether you have the extension installed locally) for the first entry that appears.
+   (might be called `Get Started - <USERNAME> [WSL: Ubuntu <VERSION-NUMBER>] Visual Studio Code`) will open up.
+   It should say `WSL` in the bottom left corner of the window.
+1. In the **WSL VSCode window**, open the **Extensions** panel again (or `Ctrl+Shift+X`).
+   Search for each of the following extensions and click `Install`
+   (or `Install in WSL: Ubuntu`, depending on whether you already have the extension installed locally) for the first entry that appears.
    If no `Install` button is available and the extension is not grayed out,
    it means it is already installed.
 
@@ -114,9 +113,9 @@ Verify that the extensions you have just installed exist in the list under `WSL:
 
 #### WSL2 Ubuntu terminal in VSCode
 
-You can open a terminal in your WSL VSCode window (if you do not already have
-one at the bottom of the window) by navigating to **Terminal > New Terminal** in
-the top menu bar (or, `` Ctrl+Shift+` ``). This terminal in a WSL VSCode window
+You can open the terminal in your **WSL VSCode window** (if you do not already have
+one at the bottom of the window) by navigating to **View > Terminal** in
+the top menu bar (or, `` Ctrl+` ``). This terminal in a WSL VSCode window
 is equivalent to the WSL2 Ubuntu terminal we get from opening the Ubuntu app
 itself (i.e., like we did from the **Start (Win key)** menu), but with the
 advantage of having all the graphical features of VSCode at your disposal.
@@ -176,29 +175,29 @@ Notebook in your WSL2 Ubuntu distribution.
    click it and select the one reading something like _qlsc612
    (Python 3.x.y) miniconda3/envs/qlsc612/bin/python_.
    The button should be updated to read _qlsc612 (Python 3.x.y)_.
-   This is the python environment we have just created for this course,
+   This is the Python environment we have just created for this course,
    make sure it is the one you are using for later modules.
 
 ### Docker Desktop for Windows
 
-You are supposed to install Docker Desktop after you have successfully installed WSL2.
+You should install Docker Desktop after you have successfully installed WSL2.
 
 1. Go to [this page](https://docs.docker.com/desktop/install/windows-install/)
    and click "Docker Desktop for Windows", then run the downloaded installer.
 2. When prompted, ensure the "Use WSL 2 instead of Hyper-V option" on the
-   Configuration page is selected or not depending on your choice of backend.
+   Configuration page is selected.
 3. Follow the instructions on the installation wizard to authorize the installer
    and proceed with the install.
 4. When the installation is successful, click "Close" to complete the
-   installation process. (If your admin account is different to your user
-   account, you must add the user to the docker-users group. Run **Computer
+   installation process. (If the admin account on your computer is different to your user account, you must add the user to the docker-users group. Run **Computer
    Management** as an administrator and navigate to Local Users and Groups >
    Groups > docker-users. Right-click to add the user to the group. Log out and
    log back in for the changes to take effect.)
 5. Whenever you need to run Docker, open **Start (Win key)**, search for
    **Docker Desktop** in your applications, and left click to run the app.
-6. You can always use Docker command-line tools in **Command Prompt** or
-   **PowerShell** (as well as from your WSL2 Ubuntu terminal).
+6. For this course, you should run Docker commands from your **WSL2 Ubuntu
+   terminal**. 
+   However, in general you can also use Docker command-line tools in **Command Prompt** or **PowerShell**.
 
 The above step-by-step instructions are distilled from
 [here](https://docs.docker.com/desktop/install/windows-install/).


### PR DESCRIPTION
- Typos fixed
- New instructions created for SSH key setup instructions for GitHub auth (following feedback from last year)
- Reordered software sections on main setup page so students are less likely to miss steps (e.g., they need an existing GH account for some of the GH setup)